### PR TITLE
Fixes the handlebar helper's hash not being passed to the Faker function call.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,9 +17,9 @@ npm install handlebars-faker --save-dev
 var Handlebars = require('handlebars');
 Handlebars.registerHelper('faker', require('handlebars-faker'));
 
-var template = Handlebars.compile('{{faker "internet.email"}} {{faker "lorem.words" 3}}');
+var template = Handlebars.compile('{{faker "internet.email"}} - {{faker "lorem.words" 3}} - {{faker "random.number" min=4 max=15}}');
 console.log(template({}));
-// -> Patricia_Schamberger75@gmail.com voluptas in omnis
+// -> Patricia_Schamberger75@gmail.com - voluptas in omnis - 11
 ```
 
 # Changelog

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var faker = require('faker');
 var assert = require('assert');
+var isEmpty = require('lodash/isEmpty');
 var defaultLanguage = 'en';
 
 module.exports = function handlebarsFakerHelper (fakeName /*, [...], options */) {
@@ -13,7 +14,7 @@ module.exports = function handlebarsFakerHelper (fakeName /*, [...], options */)
   var fakerOptions = options.hash;
   var fakerArguments = Array.prototype.slice.call(arguments, 1, arguments.length - 1);
 
-  if (fakerOptions) {
+  if (fakerOptions && !isEmpty(fakerOptions)) {
     // pushes the handlebars hash into the argument list of the faker call.
     // this ensures faker methods that depend on option objects like Faker.random.number({min, max, precision})
     // can be properly given their options object.

--- a/index.js
+++ b/index.js
@@ -10,10 +10,20 @@ module.exports = function handlebarsFakerHelper (fakeName /*, [...], options */)
 
   var fakeFunction = faker[fakeNameParts[0]][fakeNameParts[1]];
   var options = arguments[arguments.length - 1];
+  var fakerOptions = options.hash;
   var fakerArguments = Array.prototype.slice.call(arguments, 1, arguments.length - 1);
+
+  if (fakerOptions) {
+    // pushes the handlebars hash into the argument list of the faker call.
+    // this ensures faker methods that depend on option objects like Faker.random.number({min, max, precision})
+    // can be properly given their options object.
+    fakerArguments.push(fakerOptions);
+  }
+
   var language = options.hash.lang || defaultLanguage;
   var fakerLanguage = faker.locale;
   faker.locale = language;
+
   var result = fakeFunction.apply(faker, fakerArguments);
   faker.locale = fakerLanguage;
   return result;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "handlebars": "^4.0.5",
+    "lodash": "^4.17.2",
     "mocha": "^2.5.3",
     "semistandard": "^8.0.0",
     "sinon": "^1.17.4"

--- a/test/test.js
+++ b/test/test.js
@@ -28,4 +28,21 @@ describe('handlebars-faker', function () {
     assert(faker.lorem.words.withArgs('2').calledOnce);
     faker.lorem.words.restore();
   });
+  it('should generate a random number', function () {
+    sinon.spy(faker.random, 'number');
+    var result = Handlebars.compile('{{faker "random.number" }}')({});
+    assert.isNumber(parseInt(result, 10));
+    assert(faker.random.number.calledOnce);
+    faker.random.number.restore();
+  });
+  it('should generate a random number when passing an options object as an argument', function () {
+    sinon.spy(faker.random, 'number');
+    var result = Handlebars.compile('{{faker "random.number" min=4 max=15 precision=1 }}')({});
+    var parsedResult = parseInt(result, 10);
+    assert(faker.random.number.withArgs({min: 4, max: 15, precision: 1}).calledOnce);
+    assert.isNumber(parsedResult);
+    assert.isAtLeast(parsedResult, 4);
+    assert.isAtMost(parsedResult, 15);
+    faker.random.number.restore();
+  });
 });


### PR DESCRIPTION
In trying to use the `Faker.random.number` function with the `min` and `max` options I noticed that these cannot be specified using handlebar template helper markup.

The most intuitive way seemed to use the helper hash as follows:

```js
{{faker "random.number" min=4 max=9}}
```

The "options" where already captured in `index.js` to extract the `locale` information but the data wasn't given to the `fakerArguments` list and as such meaningful options such as `min`, `max`, `precision` etc weren't correctly passed onto the Faker function.

I've added 2 additional tests to cover at least the `Faker.random.number` scenario but please let me know if you need any other parts covered with test for this PR to be merged.

Lastly, I did not bump the version number in the `package.json` as I am assuming you will take care of that once merged and a release is published to NPM. Let me know if you want me to bump this instead please.

Any questions just let me know :)